### PR TITLE
Fix typo from 'eval' to 'val'

### DIFF
--- a/dataset/tiktok_video_dataset.py
+++ b/dataset/tiktok_video_dataset.py
@@ -293,7 +293,7 @@ class BaseDataset(TsvCondImgCompositeDataset):
             idx = int(idx * self.train_sample_interval)
             idx = idx + random.randint(0, self.train_sample_interval - 1)
             idx = min(idx, len(self) - 1)
-        elif self.split == "eval":
+        elif self.split == "val":
             idx = int(idx * self.eval_sample_interval)
 
         raw_data = self.get_metadata(idx)


### PR DESCRIPTION
This typo caused the frames not to be sampled correctly according to self.eval_sample_interval.